### PR TITLE
Removing the trailing slash for the baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "/" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://schema.mobivoc.org" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings


### PR DESCRIPTION
Removing the trailing slash for the baseurl should be a workaround for https://github.com/white-gecko/jekyll-rdf/issues/148