### PR TITLE
Fix the resource template to not crash using a workaround

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -3,7 +3,7 @@
 {% comment %} iri:"{{iri | escape }}" {% endcomment %}
 {%- assign linksResource = iri | rdf_get -%}
 
-<h2>Linked Resources</h2>
+<h3>Linked Resources</h3>
 {%- capture query -%}
 SELECT ?predicate ?object
 WHERE {
@@ -27,7 +27,7 @@ WHERE {
     {% endfor %}
 </ul>
 
-<h2>Resources linking here</h2>
+<h3>Resources linking here</h3>
 {%- capture query -%}
 SELECT ?subject ?predicate
 WHERE {
@@ -51,7 +51,7 @@ WHERE {
     {% endfor %}
 </ul>
 
-<h2>Resources using this as predicate</h2>
+<h3>Resources using this as predicate</h3>
 {%- capture query -%}
 SELECT ?subject
 WHERE {

--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -4,4 +4,16 @@ rdf_prefix_path: prefixes.pref
 ---
 resource
 
+{% comment %} if page.rdf.covered {% endcomment %}
+{%- capture iri -%}<{{page.rdf.iri}}>{%- endcapture -%}
+{%- assign linksResource = iri | rdf_get -%}
+linksResource: {{linksResource}}
+{% if linksResource %}
+<h2>Linked Resources for {{ page.rdf.iri }}</h2>
 {% include links.html iri = page.rdf.iri %}
+{% endif %}
+
+{% for ancor in page.sub_rdf %}
+<h2>Linked Resources for {{ ancor }}</h2>
+{% include links.html iri = ancor %}
+{% endfor %}


### PR DESCRIPTION
This fix avoids the inclusion of the links template for resources which are not covered by the graph (i.e. the uri of the rendered page is not mentioned).
Further pull request also includes the links template for hash-sub-resources ;-)