### PR TITLE
Fix to ruby 3.1 for now due to some issue with 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3-slim AS builder
+FROM ruby:3.1-slim AS builder
 
 RUN apt-get update && apt-get -y install build-essential && rm -rf /var/lib/apt/lists/*
 WORKDIR jekyll-theme-jod
@@ -7,7 +7,7 @@ ADD . .
 RUN gem build jekyll-theme-jod.gemspec && \
     gem install jekyll-theme-jod-*.gem mustache
 
-FROM ruby:3-slim
+FROM ruby:3.1-slim
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /jekyll-theme-jod/docker-resources/ /docker-resources
 RUN apt-get update && apt-get -y install jq && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fix to ruby 3.1 for now due to the failing sparql library with 3.2.0 cf. https://github.com/ruby-rdf/sparql/issues/45